### PR TITLE
Replace broken nomation form with an email link

### DIFF
--- a/signup/how_to_apply.html
+++ b/signup/how_to_apply.html
@@ -72,35 +72,7 @@
 					<p>It only takes a few minutes to start the application process for CJSM. If you're ready, you can <a href="https://www.cjsm.net/ApplicationHome.do" target="_blank" title="Apply Now">Apply Now (opens in a new tab)</a> via our online application.</p>
 
 					<h2>Nominate another organisation</h2>
-					<p>If you're already a CJSM user and you'd like to invite another organisation within the justice system to apply, then fill in some details and we'll send an introductory message.</p>
-
-
-					<form id="cjsm_form" action="https://formspree.io/cjsm.helpdesk@egress.com" method="post">
-					<div class="content-single-column-dotted">
-
-						<h3>Details</h3>
-						<p /><label for="cjsm_signup_name">Your name: </label><input type="text" name="cjsm_signup_name" value="" id="cjsm_signup_name" class="text-input" /> <span class="mand-text-large">*</span>
-						<br /><label for="cjsm_signup_email">Your email address: </label><input type="text" name="cjsm_signup_email" value="" id="cjsm_signup_email" class="text-input" /> <span class="mand-text-large">*</span>
-						<br /><label for="cjsm_signup_friend_name">Organisation: </label><input type="text" name="cjsm_signup_friend_name" value="" id="cjsm_signup_friend_name" class="text-input" /> <span class="mand-text-large">*</span>
-						<br /><label for="cjsm_signup_friend_email">Contact email address: </label><input type="text" name="cjsm_signup_friend_email" value="" id="cjsm_signup_friend_email" class="text-input" /> <span class="mand-text-large">*</span>
-						<br />
-						<label for="cjsm_signup_comments">Comments: </label><textarea name="cjsm_signup_comments" id="cjsm_signup_comments" class="text-area" rows="5" cols="5"></textarea> <span class="mand-text-large">*</span>
-						<p />
-
-						<div id="submit-box">
-							<input type="button" name="submit"  value="Submit" class="submit-button" alt="Submit" />
-							<a id="reset-button-link" href="#">
-								<input type="button" name="reset" value="Reset" class="reset-button" alt="Reset" /></a>
-							<input type="hidden" name="cjsm_signup_submit" value="true" />
-						</div>
-
-					</div>
-
-
-					</form>
-
-
-
+					<p>If you're already a CJSM user and you'd like to invite another organisation within the justice system to apply, then email us: <a href="mailto:cjsm.helpdesk@egress.com" title="Introduce an organisation to CJSM">cjsm.helpdesk@egress.com</a> supplying their contact email address, and we'll send an introductory message.</p>
 
 					<h2 class="pushtop">What can I expect after I apply?</h2>
 					<p>There are a few steps we'll ask you to complete before your CJSM account is activated.</p>


### PR DESCRIPTION
Looks like this form has been broken for several years.

These forms could be resurrected using a service such as formspree.io, however it is one more thing to setup and manage, and hopefully asking people to email is acceptable.