### PR TITLE
Remove broken contact form option

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -181,44 +181,6 @@
 						<p><strong>Email us at</strong><br>
 						<a href="mailto:cjsm.helpdesk@egress.com">cjsm.helpdesk@egress.com</a></p>
 
-
-						<h2 class="small">Or fill in this form</h2>
-						<p>We won't pass your personal details to anyone else. We might get in contact with you to find out more about your issue.</p>
-						<p>Please answer all questions marked with an asterisk *</p>
-
-						<div class="content-single-column-dotted flush-top">
-
-
-
-						  <form id="cjsm_form" action="http://cjsm.dsd.io/contact/enquiries.php" method="post">
-						  <div class="content-single-column-dotted">
-
-						      <!-- <h3>Personal Details</h3> -->
-						      <p class="mand-text">* marked fields are mandatory</p>
-						                      <label for="cjsm_enquiry_name">Name: </label><input type="text" name="cjsm_enquiry_name" value="" id="cjsm_enquiry_name" class="text-input" /> <span class="mand-text-large">*</span>
-						      <br />
-						                      <label class="left_text" for="cjsm_enquiry_tel">Telephone number: </label><input type="text" name="cjsm_enquiry_tel" value="" id="cjsm_enquiry_tel" class="text-input" />
-						      <br />
-						                      <label class="left_text" for="cjsm_enquiry_email">Email: </label><input type="text" name="cjsm_enquiry_email" value="" id="cjsm_enquiry_email" class="text-input" /> <span class="mand-text-large">*</span>
-						      <br />
-						      <label class="left_text" for="cjsm_enquiry_organisation">Organisation: </label><input type="text" name="cjsm_enquiry_organisation" value="" id="cjsm_enquiry_organisation" class="text-input" />
-						      <br />
-						      <label class="left_text" for="cjsm_enquiry_enquiry">What can we help you with / What would you like to tell us?: </label><textarea name="cjsm_enquiry_enquiry" id="cjsm_enquiry_enquiry" class="text-area" rows="5" cols="5"></textarea> <span class="mand-text-large">*</span>
-						      <p />
-						    </div>
-
-						    <div id="submit-box">
-						      <input type="button" name="submit" value="Submit" class="submit-button" alt="Submit" />
-						      <a id="reset-button-link" href="#"><input type="button" name="reset" value="Reset" class="reset-button" alt="Reset" /></a>
-						      <input type="hidden" name="cjsm_enquiry_submit" value="true" />
-						    </div>
-						    </form>
-
-						  </div>
-
-
-
-
 								<!-- <ul>
 										<li><a href="../faqs/index.html">Password reset</a></li>
 										<li><a href="../faqs/admin_faqs.html">Storage limits</a></li>


### PR DESCRIPTION
Users can instead use the phone number and email address options above it.